### PR TITLE
 Application folders on Mac are now correct. Fixes #40353

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
@@ -97,6 +97,12 @@ namespace System
                 case SpecialFolder.UserProfile:
                 case SpecialFolder.MyDocuments: // same value as Personal
                     return home;
+#if TARGET_OSX
+                case SpecialFolder.ApplicationData:
+                    return "/Library/Application Support";
+                case SpecialFolder.LocalApplicationData:
+                  return Path.Combine(home, "Library/Application Support");
+#else
                 case SpecialFolder.ApplicationData:
                     return GetXdgConfig(home);
                 case SpecialFolder.LocalApplicationData:
@@ -108,7 +114,7 @@ namespace System
                         data = Path.Combine(home, ".local", "share");
                     }
                     return data;
-
+#endif
                 case SpecialFolder.Desktop:
                 case SpecialFolder.DesktopDirectory:
                     return ReadXdgDirectory(home, "XDG_DESKTOP_DIR", "Desktop");


### PR DESCRIPTION
Environment SpecialFolder.ApplicationData and LocalApplication now point to Mac library folders